### PR TITLE
pr-approvals-count: duplicate tooltip

### DIFF
--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -17,3 +17,7 @@
 .js-issue-row .color-text-secondary [aria-label*='changes'] {
 	color: var(--github-red) !important;
 }
+
+[aria-label*='approval']:after {
+	content: none;
+}


### PR DESCRIPTION
I don't need extra branches I guess?